### PR TITLE
Fix partially matching origins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,6 @@ build/
 
 # unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
 .rvmrc
+
+# vim swap files
+.*.swp

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,4 @@
+require 'rspec/core/rake_task'
+require 'bundler/gem_tasks'
+
+RSpec::Core::RakeTask.new

--- a/lib/akamai_rspec/matchers/matchers.rb
+++ b/lib/akamai_rspec/matchers/matchers.rb
@@ -6,20 +6,26 @@ require_relative 'non_akamai'
 require_relative 'honour_origin_headers'
 include AkamaiHeaders
 
-RSpec::Matchers.define :x_cache_key_contains do |contents|
+RSpec::Matchers.define :be_served_from_origin do |contents|
+  match do |url|
+    response = RestClient::Request.responsify url
+    fail 'No X-Cache-Key header' if response.headers[:x_cache_key].nil?
+    unless response.headers[:x_cache_key] =~ /\/#{contents}\//
+      fail("x_cache_key has value '#{response.headers[:x_cache_key]}' which doesn't match '#{contents}'")
+    end
+    response.code == 200
+  end
+end
+
+RSpec::Matchers.define :have_cp_code do |contents|
   match do |url|
     response = RestClient::Request.responsify url
     fail 'No X-Cache-Key header' if response.headers[:x_cache_key].nil?
     unless response.headers[:x_cache_key].include?(contents)
       fail("x_cache_key has value '#{response.headers[:x_cache_key]}' which doesn't include '#{contents}'")
     end
-    response.code == 200 && response.headers[:x_cache_key].include?(contents)
+    response.code == 200
   end
-end
-
-module RSpec::Matchers
-  alias_method :be_served_from_origin, :x_cache_key_contains
-  alias_method :have_cp_code, :x_cache_key_contains
 end
 
 RSpec::Matchers.define :be_forwarded_to_index do |channel|

--- a/spec/matchers/matchers_spec.rb
+++ b/spec/matchers/matchers_spec.rb
@@ -19,7 +19,7 @@ end
 
 describe 'be_served_from_origin' do
   before(:each) do
-    x_cache = { 'x-cache-key' => 'origin' }
+    x_cache = { 'x-cache-key' => 'A/B/1234/123456/000/originsite.example.com/' }
     stub_headers('/correct', x_cache)
     stub_request(:any, DOMAIN + '/redirect').to_return(
       body: 'abc', headers: x_cache,
@@ -27,16 +27,21 @@ describe 'be_served_from_origin' do
   end
 
   it 'should succeed with 200 and correct origin' do
-    expect(DOMAIN + '/correct').to be_served_from_origin('origin')
+    expect(DOMAIN + '/correct').to be_served_from_origin('originsite.example.com')
   end
 
   it 'should fail on 300 and correct origin' do
-    expect { expect(DOMAIN + '/redirect').to be_served_from_origin('origin') }
+    expect { expect(DOMAIN + '/redirect').to be_served_from_origin('originsite.example.com') }
       .to raise_error(RuntimeError)
   end
 
   it 'should fail on 200 and incorrect origin' do
-    expect { expect(DOMAIN + '/correct').to be_served_from_origin('incorrect') }
+    expect { expect(DOMAIN + '/correct').to be_served_from_origin('someothersite.example.com') }
+      .to raise_error(RuntimeError)
+  end
+
+  it 'should fail on 200 and origin that only partially matches' do
+    expect { expect(DOMAIN + '/correct').to be_served_from_origin('site.example.com') }
       .to raise_error(RuntimeError)
   end
 end


### PR DESCRIPTION
Hi

If I'm not mistaken it looks like there is a bug in the `be_served_from_origin` matcher. If an origin was `something.com`, this matcher would pass for `thing.com` etc...

I ended up removing the alias methods and separating each out. Also the check at the end of the matcher was redundant so I've removed that too. The `x-cache-key` that I am using in the tests is "real" (with sites and numbers changed). I am assuming the format is consistent (but I might be wrong).

I've also added a Rakefile (It gives you similar functionality to what is in `rebuild_and_install.sh`). You might find this useful - I generally prefer performing tasks on a project via rake.

Thanks!
Ryan
