### PR TITLE
Queries are going to the real url, not the Akamai URL.

### DIFF
--- a/spec/unit/request_spec.rb
+++ b/spec/unit/request_spec.rb
@@ -61,4 +61,16 @@ describe RestClient::Request do
       expect(RestClient::Request.https_url(path)).to eq("https://#{prod_domain}/")
     end
   end
+
+  it 'queries the staging host' do
+    RestClient::Request.akamai_network('staging')
+    expect(Net::HTTP).to receive(:new).with(stg_domain, anything)
+    RestClient::Request.responsify 'example.com'
+  end
+
+  it 'queries the staging host' do
+    RestClient::Request.akamai_network('production')
+    expect(Net::HTTP).to receive(:new).with(prod_domain, anything)
+    RestClient::Request.responsify 'example.com'
+  end
 end


### PR DESCRIPTION
This PR so far only adds some failing tests to show that this is broken.

The Monkey Patch of RestClient is rather fragile. I think the solution to this is to remove RestClient all together; as it's only being used to wrap around Net::HTTP and URI modules it would be much easier to re-write the `Request` method to just use Net::HTTP directly. Let me know your thoughts.