### PR TITLE
Use debug headers for cache

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ AkamaiRSpec::Request.stg_domain = "www.example.com.edgesuite-staging.net"
 
 The default akamai network used is prod, to test in staging you must specify.
 ```
-AkamaiRSpec::Request.akamai_network = "staging"
+AkamaiRSpec::Request.network = "staging"
 ```
 
 ### matchers

--- a/lib/akamai_rspec/matchers/caching.rb
+++ b/lib/akamai_rspec/matchers/caching.rb
@@ -3,7 +3,7 @@ require 'securerandom'
 
 RSpec::Matchers.define :be_cacheable do
   match do |url|
-    response = AkamaiRSpec::Request.get url
+    response = AkamaiRSpec::Request.get_with_debug_headers url
     x_check_cacheable(response, 'YES')
     response.code == 200
   end
@@ -24,7 +24,7 @@ end
 
 RSpec::Matchers.define :not_be_cached do
   match do |url|
-    response = AkamaiRSpec::Request.get url
+    response = AkamaiRSpec::Request.get_with_debug_headers url
     x_check_cacheable(response, 'NO')
     response = AkamaiRSpec::Request.get url  # again to prevent spurious cache miss
 

--- a/lib/akamai_rspec/matchers/caching.rb
+++ b/lib/akamai_rspec/matchers/caching.rb
@@ -26,7 +26,7 @@ RSpec::Matchers.define :not_be_cached do
   match do |url|
     response = AkamaiRSpec::Request.get_with_debug_headers url
     x_check_cacheable(response, 'NO')
-    response = AkamaiRSpec::Request.get url  # again to prevent spurious cache miss
+    response = AkamaiRSpec::Request.get_with_debug_headers url  # again to prevent spurious cache miss
 
     not_cached = response.headers[:x_cache] =~ /TCP(\w+)?_MISS/
     if not_cached


### PR DESCRIPTION
Context
----
`be_cacheable` and `not_be_cached` fail because they can't find the `X-Cache` header

```
  2) staging network requests are not cacheable
     Failure/Error: expect(url).to not_be_cached.and be_forbidden

     RuntimeError:
       x_cache header does not indicate an origin hit: ''
```

Changes
----
Use debug headers when checking cacheability

Bonus changes
----
Fix the README documentation