### PR TITLE
Keep either url or response

### DIFF
--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -71,7 +71,6 @@ module AkamaiRSpec
 
     def get(url, headers = {})
       if url.is_a? RestClient::Response
-        warn 'This functionality is deprecated and will be removed in the next release'
         return AkamaiRSpec::Response.new(url)
       end
 


### PR DESCRIPTION
I disagree with removing the response option, I'm not sure why I
accepted it. I think that it's nice to be able to use either a url or
response, it's helpful when the user wants to check something about the
response that akamai-rspec doesn't support. I also don't want to have to
change the existing tests without a good reason.

I think I may have just accepted it because I was so happy that a
stranger sent me a PR, and that clouded my judgement.