### PR TITLE
Fix for failing secure check when 404 received

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akamai_rspec (1.2.3)
+    akamai_rspec (1.2.4)
       json (~> 2.1)
       rest-client (~> 1.8)
       rspec (~> 3.6)

--- a/akamai_rspec.gemspec
+++ b/akamai_rspec.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'akamai_rspec'
-  s.version     = "1.2.3"
+  s.version     = "1.2.4"
   s.authors     = ['Bianca Gibson', 'Daniel Heath']
   s.email       = 'cobweb@rea-group.com'
   s.files       = Dir['lib/*']

--- a/lib/akamai_rspec/matchers/non_akamai.rb
+++ b/lib/akamai_rspec/matchers/non_akamai.rb
@@ -42,8 +42,15 @@ module AkamaiRSpec
         rescue RestClient::MaxRedirectsReached
           return true # Securely sent a redirect
         rescue Exception => e
-          @error = e
-          return false
+          begin
+            if e.response # Securely sent a non-success HTTP code
+                          # See: https://github.com/rest-client/rest-client/tree/1.8.x#exceptions-see-wwww3orgprotocolsrfc2616rfc2616-sec10html
+              return true
+            end
+          rescue Exception => exception_on_reading_response
+            @error = exception_on_reading_response
+            return false
+          end
         end
       end
 

--- a/spec/functional/non_akamai_spec.rb
+++ b/spec/functional/non_akamai_spec.rb
@@ -90,6 +90,14 @@ describe 'be_verifiably_secure' do
       expect("https://#{DOMAIN}").to be_verifiably_secure
     end
   end
+
+  describe 'verifying a URL with the https protocol that returns infinite 301' do
+    it "succeeds when it verifies correctly" do
+      stub_request(:any, "https://#{DOMAIN}/301loop").
+        to_return(body: 'loop', status: [301, 'loop'], headers: { 'Location' => "https://#{DOMAIN}/301loop" },)
+      expect("https://#{DOMAIN}/301loop").to be_verifiably_secure
+    end
+  end
 end
 
 describe 'be_forbidden' do

--- a/spec/functional/non_akamai_spec.rb
+++ b/spec/functional/non_akamai_spec.rb
@@ -98,6 +98,14 @@ describe 'be_verifiably_secure' do
       expect("https://#{DOMAIN}/301loop").to be_verifiably_secure
     end
   end
+
+  describe 'verifying a URL with the https protocol that returns 404' do
+    it "succeeds when it verifies correctly" do
+      stub_request(:any, "https://#{DOMAIN}/notfound").
+        to_return(body: 'not found', status: [404, 'not found'])
+      expect("https://#{DOMAIN}/notfound").to be_verifiably_secure
+    end
+  end
 end
 
 describe 'be_forbidden' do


### PR DESCRIPTION
This PR adds:
- a test for looping 301's (max redirects)
- a test for secure delivery of non-success HTTP codes
- a fix so that `be_verifiably_secure` passes if it receives a non-success HTTP code securely