### PR TITLE
Adding mutator for debugmethods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 Change history / upgrade notes
 
+# 1.2.5
+
+`AkamaiRSpec::Request.debug_headers` changed to be a member variable instead of a property method.
+
+`AkamaiRSpec::Request.add_debug_header` method added to inject additional headers.
+
 # 1.2.2
 
 `be_cacheable` now makes requests for the same resource until it gets N requests (default=4) served by the same edge node.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akamai_rspec (1.2.4)
+    akamai_rspec (1.2.5)
       json (~> 2.1)
       rest-client (~> 1.8)
       rspec (~> 3.6)

--- a/akamai_rspec.gemspec
+++ b/akamai_rspec.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'akamai_rspec'
-  s.version     = "1.2.4"
+  s.version     = "1.2.5"
   s.authors     = ['Bianca Gibson', 'Daniel Heath']
   s.email       = 'cobweb@rea-group.com'
   s.files       = Dir['lib/*']

--- a/lib/akamai_rspec/request.rb
+++ b/lib/akamai_rspec/request.rb
@@ -6,9 +6,26 @@ module AkamaiRSpec
     extend Forwardable
 
     class << self
-      attr_accessor :stg_domain, :prod_domain, :network
+      attr_accessor :stg_domain, :prod_domain, :network, :debug_headers
     end
     self.network = 'prod'
+    self.debug_headers = {
+      pragma: [
+        'akamai-x-cache-on',
+        'akamai-x-cache-remote-on',
+        'akamai-x-check-cacheable',
+        'akamai-x-get-cache-key',
+        'akamai-x-get-extracted-values',
+        'akamai-x-get-nonces',
+        'akamai-x-get-ssl-client-session-id',
+        'akamai-x-get-true-cache-key',
+        'akamai-x-serial-no'
+      ].join(", ")
+    }
+
+    def self.add_debug_header(key, value)
+      self.debug_headers["#{key}"]  = value
+    end
 
     def self.get(url, headers={})
       new.get(url, headers.merge(debug_headers))
@@ -28,22 +45,6 @@ module AkamaiRSpec
       response = new.get(url, debug_headers.merge({'Accept-Encoding' => 'gzip'}))
       RestClient::Request.decode(response.headers[:content_encoding], response.body)
       response
-    end
-
-    def self.debug_headers
-      {
-        pragma: [
-          'akamai-x-cache-on',
-          'akamai-x-cache-remote-on',
-          'akamai-x-check-cacheable',
-          'akamai-x-get-cache-key',
-          'akamai-x-get-extracted-values',
-          'akamai-x-get-nonces',
-          'akamai-x-get-ssl-client-session-id',
-          'akamai-x-get-true-cache-key',
-          'akamai-x-serial-no'
-        ].join(", ")
-      }
     end
 
     def initialize


### PR DESCRIPTION
We needed to inject custom headers for different calls to Akamai.
`AkamaiRSpec::Request.debug_headers` changed to be a member variable instead of a property method.
`AkamaiRSpec::Request.add_debug_header` method added to inject additional headers.
Version bump
CHANGELOG update.