### PR TITLE
Temporary redirects matchers now accepts 302 _and_ 307 response codes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 Change history / upgrade notes
 
-# 1.2.6
+# 1.2.7
 
 Temporary redirects matchers now accepts 302 _and_ 307 response codes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Change history / upgrade notes
 
+# 1.2.6
+
+Temporary redirects matchers now accepts 302 _and_ 307 response codes.
+
 # 1.2.5
 
 `AkamaiRSpec::Request.debug_headers` changed to be a member variable instead of a property method.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akamai_rspec (1.2.6)
+    akamai_rspec (1.2.7)
       json (~> 2.1)
       rest-client (~> 1.8)
       rspec (~> 3.6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    akamai_rspec (1.2.5)
+    akamai_rspec (1.2.6)
       json (~> 2.1)
       rest-client (~> 1.8)
       rspec (~> 3.6)

--- a/akamai_rspec.gemspec
+++ b/akamai_rspec.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'akamai_rspec'
-  s.version     = "1.2.6"
+  s.version     = "1.2.7"
   s.authors     = ['Bianca Gibson', 'Daniel Heath']
   s.email       = 'cobweb@rea-group.com'
   s.files       = Dir['lib/*']

--- a/akamai_rspec.gemspec
+++ b/akamai_rspec.gemspec
@@ -2,7 +2,7 @@ $LOAD_PATH.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'akamai_rspec'
-  s.version     = "1.2.5"
+  s.version     = "1.2.6"
   s.authors     = ['Bianca Gibson', 'Daniel Heath']
   s.email       = 'cobweb@rea-group.com'
   s.files       = Dir['lib/*']

--- a/lib/akamai_rspec/helpers/chainable_redirect.rb
+++ b/lib/akamai_rspec/helpers/chainable_redirect.rb
@@ -17,9 +17,17 @@ module AkamaiRSpec
 
       def redirect(url, expected_location, expected_response_code, headers)
         response = AkamaiRSpec::Request.get(url, headers)
-        fail "Response was #{response.inspect}, expected code #{expected_response_code}" unless response.code == expected_response_code
-        unless expected_location === response.headers[:location]
-          fail "redirect location was #{response.headers[:location]} (expected #{expected_location})"
+
+        if expected_response_code.kind_of?(Array)
+          fail "Response was #{response.inspect}, expected code #{expected_response_code}" unless expected_response_code.include? response.code
+          unless expected_location === response.headers[:location]
+            fail "redirect location was #{response.headers[:location]} (expected #{expected_location})"
+          end
+        else
+          fail "Response was #{response.inspect}, expected code #{expected_response_code}" unless response.code == expected_response_code
+          unless expected_location === response.headers[:location]
+            fail "redirect location was #{response.headers[:location]} (expected #{expected_location})"
+          end
         end
 
         if @and_then_matchers

--- a/lib/akamai_rspec/matchers/redirects.rb
+++ b/lib/akamai_rspec/matchers/redirects.rb
@@ -14,7 +14,7 @@ module AkamaiRSpec
     define :be_temporarily_redirected_to do |expected_location, headers: {}|
       include AkamaiRSpec::Helpers::ChainableRedirect
       match do |url|
-        redirect(url, expected_location, 302, headers)
+        redirect(url, expected_location, [ 302, 307 ], headers)
       end
     end
 


### PR DESCRIPTION
Apparently the RFC likes 307's for redirects instead of the infamously ambiguous 302. who would have thunk it?

Being that we use the 302's everywhere it makes sense to add 307 rather than replace.